### PR TITLE
ci: add GitHub Actions build check mirroring Cloudflare

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build
+
+# Mirrors the Cloudflare Pages build so build breakages are visible in GitHub
+# (red ✗ on the commit/PR + failure email to the committer) without needing
+# access to the Cloudflare dashboard. This does not deploy — Cloudflare still
+# handles that.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
           cache: npm


### PR DESCRIPTION
## Problem

Builds run on Cloudflare Pages, but the content maintainer has no Cloudflare dashboard access — so when a build breaks, they can't see the logs or even know it failed.

## Change

Adds `.github/workflows/build.yml` that runs the **same build Cloudflare runs** (`npm ci` + `npm run build`, Node pinned via `.nvmrc` → 22.21.0) on every push to `main` and every PR.

- **Does not deploy** — Cloudflare still handles deployment. This is purely a visibility mirror.
- Build failures now appear as a red ✗ check on the commit/PR in the GitHub UI and trigger a failure email to the committer, with the full log in the Actions tab — no Cloudflare access needed.

Verified `npm run build` passes locally on Node 22.21.0.

## Follow-ups (not in this PR)

- Ensure the maintainer is a repo collaborator with failed-workflow notifications enabled.
- Optionally add a branch protection rule on `main` requiring the `build` check to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)